### PR TITLE
feat: Implement Potentiation Operation (a^b)

### DIFF
--- a/src/main/java/com/tomwey2/calculator/CalculatorController.java
+++ b/src/main/java/com/tomwey2/calculator/CalculatorController.java
@@ -28,4 +28,13 @@ public class CalculatorController {
             return "Error: " + e.getMessage();
         }
     }
+
+    @RequestMapping("/potentiation")
+    String potentiation(@RequestParam("a") Integer a, @RequestParam("b") Integer b) {
+        try {
+            return String.valueOf(calculatorService.potentiation(a, b));
+        } catch (ArithmeticException e) {
+            return "Error: " + e.getMessage();
+        }
+    }
 }

--- a/src/main/java/com/tomwey2/calculator/CalculatorService.java
+++ b/src/main/java/com/tomwey2/calculator/CalculatorService.java
@@ -18,4 +18,39 @@ public class CalculatorService {
         }
         return (double) a / b;
     }
+
+    /**
+     * Calculates a^b (a raised to the power of b).
+     * 
+     * @param a the base
+     * @param b the exponent
+     * @return the result of a^b
+     * @throws ArithmeticException if a = 0 and b = 0 (undefined)
+     */
+    public double potentiation(int a, int b) {
+        if (a == 0 && b == 0) {
+            throw new ArithmeticException("0^0 is undefined.");
+        }
+        
+        if (b == 0) {
+            return 1;
+        }
+        
+        if (b < 0) {
+            return 1.0 / positivePotentiation(a, -b);
+        }
+        
+        return positivePotentiation(a, b);
+    }
+
+    /**
+     * Helper method to calculate a^b for positive exponents.
+     */
+    private double positivePotentiation(int a, int b) {
+        double result = 1;
+        for (int i = 0; i < b; i++) {
+            result *= a;
+        }
+        return result;
+    }
 }

--- a/src/test/java/com/tomwey2/calculator/CalculatorServiceTest.java
+++ b/src/test/java/com/tomwey2/calculator/CalculatorServiceTest.java
@@ -48,4 +48,26 @@ class CalculatorServiceTest {
         });
         assertEquals("Division by zero is not allowed.", exception.getMessage());
     }
+
+    @Test
+    public void potentiationTest() {
+        // Basic potentiation
+        assertEquals(8.0, calculatorService.potentiation(2, 3));
+        assertEquals(1.0, calculatorService.potentiation(5, 0));
+        assertEquals(1.0, calculatorService.potentiation(1, 100));
+        
+        // Potentiation with negative base
+        assertEquals(-8.0, calculatorService.potentiation(-2, 3));
+        assertEquals(4.0, calculatorService.potentiation(-2, 2));
+        
+        // Potentiation with negative exponent
+        assertEquals(0.5, calculatorService.potentiation(2, -1));
+        assertEquals(0.25, calculatorService.potentiation(2, -2));
+        
+        // Edge case: 0^0 (undefined)
+        ArithmeticException exception = assertThrows(ArithmeticException.class, () -> {
+            calculatorService.potentiation(0, 0);
+        });
+        assertEquals("0^0 is undefined.", exception.getMessage());
+    }
 }


### PR DESCRIPTION
This PR implements the potentiation operation (a^b) in the calculator application.

### Changes:
- Added `potentiation` method in `CalculatorService` to calculate a^b.
- Added REST endpoint `/potentiation` in `CalculatorController` to expose the functionality.
- Added comprehensive tests for the new functionality in `CalculatorServiceTest`.

### Edge Cases Handled:
- 0^0 throws an `ArithmeticException` (undefined).
- Negative exponents return a double (e.g., 2^-1 = 0.5).
- Large numbers are handled within the limits of Java's `double` type.