### PR TITLE
feat: Implement Potentiation Operation (a^b)

### DIFF
--- a/src/main/java/com/tomwey2/calculator/CalculatorController.java
+++ b/src/main/java/com/tomwey2/calculator/CalculatorController.java
@@ -28,4 +28,9 @@ public class CalculatorController {
             return "Error: " + e.getMessage();
         }
     }
+
+    @RequestMapping("/potentiation")
+    String potentiation(@RequestParam("a") Integer a, @RequestParam("b") Integer b) {
+        return String.valueOf(calculatorService.potentiation(a, b));
+    }
 }

--- a/src/main/java/com/tomwey2/calculator/CalculatorService.java
+++ b/src/main/java/com/tomwey2/calculator/CalculatorService.java
@@ -18,4 +18,14 @@ public class CalculatorService {
         }
         return (double) a / b;
     }
+
+    public double potentiation(int a, int b) {
+        if (a == 0 && b == 0) {
+            return 1; // Handling 0^0 as 1 for simplicity
+        }
+        if (b < 0) {
+            return 1.0 / Math.pow(a, -b);
+        }
+        return Math.pow(a, b);
+    }
 }

--- a/src/test/java/com/tomwey2/calculator/CalculatorServiceTest.java
+++ b/src/test/java/com/tomwey2/calculator/CalculatorServiceTest.java
@@ -48,4 +48,19 @@ class CalculatorServiceTest {
         });
         assertEquals("Division by zero is not allowed.", exception.getMessage());
     }
+
+    @Test
+    public void potentiationTest() {
+        // Positive exponents
+        assertEquals(8.0, calculatorService.potentiation(2, 3));
+        assertEquals(1.0, calculatorService.potentiation(1, 100));
+        assertEquals(1.0, calculatorService.potentiation(5, 0));
+        assertEquals(0.0, calculatorService.potentiation(0, 5));
+        assertEquals(1.0, calculatorService.potentiation(0, 0)); // Edge case: 0^0
+        
+        // Negative exponents
+        assertEquals(0.5, calculatorService.potentiation(2, -1));
+        assertEquals(0.25, calculatorService.potentiation(2, -2));
+        assertEquals(-0.125, calculatorService.potentiation(-2, -3));
+    }
 }


### PR DESCRIPTION
This PR implements the potentiation operation (a^b) in the calculator application.

### Changes:
- Added a `potentiation` method in `CalculatorService` to calculate `a^b`.
- Added a REST endpoint `/potentiation` in `CalculatorController` to expose the operation.
- Added comprehensive test cases in `CalculatorServiceTest` for the new operation.

### Edge Cases Handled:
- `0^0` returns `1` (common convention in many systems).
- Negative exponents return a double (e.g., `2^-1` returns `0.5`).

Tests have been run and passed successfully.